### PR TITLE
Changed vcpkg URL from SSH to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vcpkg"]
 	path = vcpkg
-	url = git@github.com:microsoft/vcpkg.git
+	url = https://github.com/microsoft/vcpkg.git


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

Before sending your PR, make sure only ONE of the templates is visible.
You can comment the other one or delete it entirely.

Antes de enviar tu PR, asegúrate que solo UNA de las plantillas es visible.
Puedes comentar la otra o borrarla completamente.

-->

<!-- English -->

### What does it do

This will fix cloning via HTTPS without an SSH key setup.
